### PR TITLE
Adjust logo padding

### DIFF
--- a/src/styles/components/_header.css
+++ b/src/styles/components/_header.css
@@ -7,7 +7,7 @@
 }
 
 .header__inner {
-  --padding: 8px;
+  --padding: 3px;
   --shadow: var(--hue-primary) 30% 65%;
 
   margin: var(--global-header-block-spacing);


### PR DESCRIPTION
I just saw ravynOS on Hacker News and the [top comment](https://news.ycombinator.com/item?id=32497001) is complaining about the logo being misaligned, so I figured I could fix it.

Before
![Screen Shot 2022-08-17 at 12 27 08](https://user-images.githubusercontent.com/173836/185180777-5930d69e-2f8a-4be2-9648-e4c115613f01.png)

After
![Screen Shot 2022-08-17 at 12 27 25](https://user-images.githubusercontent.com/173836/185180802-404efd2a-d319-4c91-9c20-52be169cba50.png)

